### PR TITLE
Fix menubar

### DIFF
--- a/Sources/MainMenu.swift
+++ b/Sources/MainMenu.swift
@@ -55,6 +55,7 @@ class mainMenu: QMenuBar {
     menuFile.add(action: actionOpenFile)
     menuFile.add(action: actionSaveFile)
     menuFile.add(action: actionExit)
+    add(action: menuFile.menuAction())
 
   }
 }

--- a/Sources/MainWindowController.swift
+++ b/Sources/MainWindowController.swift
@@ -19,7 +19,6 @@ class MainWindowController: QMainWindow {
     var horizontalSpacerLeft: QSpacerItem!
     var aliceKitLabels: QLabel!
     var horizontalSpacerRight: QSpacerItem!
-    var menubar: QMenuBar!
     let mainMenuMWC = mainMenu()
 
     //Init the window and all of its components
@@ -46,17 +45,12 @@ class MainWindowController: QMainWindow {
         verticalLayout.add(layout: horizontalLayout)
         self.centralWidget = centralwidget
 
-        //Initialize the menu bar and its components
-        menubar = QMenuBar(parent: self)
-        menubar.geometry = QRect(x: 0, y: 0, width: 205, height: 30)
-
         //Create the File menu and add all its members
-        mainMenuMWC.menuFile = QMenu(parent: menubar)
-
+        mainMenuMWC.menuFile = QMenu(parent: mainMenuMWC)
         mainMenuMWC.createMenu()
 
         //Attach the menubar
-        self.menuBar = menubar
+        self.menuBar = mainMenuMWC
 
     }
 }


### PR DESCRIPTION
You're creating a duplicate menubar without menus. You're attaching the menubar to the MainWindow, your instance of mainMenu isn't used anywhere, that's why the menus aren't visible.

Also, you need to add the file menu to the menubar via `add(action: menuFile.menuAction())`.